### PR TITLE
Refactor: 댓글 삭제 로직 변경

### DIFF
--- a/__tests__/article.crud.community.test.js
+++ b/__tests__/article.crud.community.test.js
@@ -67,6 +67,9 @@ describe("Article CRUD Service", () => {
               commentId: 1,
               content: "Test Comment",
               isAnonymous: false,
+              articleCommentLikes: [
+                { likedUserId: 7 }, // 댓글 좋아요
+              ],
             },
           },
         ],
@@ -74,7 +77,11 @@ describe("Article CRUD Service", () => {
           { imageUrl: "image1.jpg", sequence: 1 },
           { imageUrl: "image2.jpg", sequence: 2 },
         ],
+        articleLikes: [
+          { likedUserId: 6 }, // 게시글 좋아요
+        ],
       });
+    
 
       const article = await articleCrudService.getArticleById({
         communityId: 4,
@@ -82,16 +89,30 @@ describe("Article CRUD Service", () => {
       });
 
       // 반환된 데이터 검증
-      expect(article.articleId).toBe(1);
-      expect(article.communityId).toBe(4);
-      
-      // 호출된 findOne의 조건 검증
-      expect(article.title).toBe("Test Article");
-      expect(article.content).toBe("Test Content");
-      expect(article.isAnonymous).toBe(false);
-      expect(article.authorInfo.userId).toBe(3);
-      expect(article.articleComments[0].authorInfo.userId).toBe(5);
-      expect(article.articleImages[0].imageUrl).toContain("image1.jpg");
+  expect(article.articleId).toBe(1);
+  expect(article.communityId).toBe(4);
+  expect(article.title).toBe("Test Article");
+  expect(article.content).toBe("Test Content");
+  expect(article.isAnonymous).toBe(false);
+
+  // 작성자 정보 검증
+  expect(article.authorInfo.userId).toBe(3);
+  expect(article.authorInfo.nickname).toBe("User1");
+
+  // 댓글 정보 검증
+  expect(article.articleComments[0].commentId).toBe(1);
+  expect(article.articleComments[0].content).toBe("Test Comment");
+  expect(article.articleComments[0].authorInfo.userId).toBe(5);
+  expect(article.articleComments[0].isLikedByUser).toBe(false); // userId가 7과 다르므로 false
+  expect(article.articleComments[0].commentLikesCount).toBe(1); // 좋아요 개수 확인
+
+  // 이미지 검증
+  expect(article.articleImages[0].imageUrl).toContain("image1.jpg");
+  expect(article.articleImages[1].imageUrl).toContain("image2.jpg");
+
+  // 좋아요 및 댓글 개수 검증
+  expect(article.articleLikesCount).toBe(1); // 좋아요 개수 확인
+  expect(article.commentsCount).toBe(1); // 댓글 개수 확인
     });
 
     it("should throw NotExistsError if the article does not exist", async () => {

--- a/__tests__/article.crud.community.test.js
+++ b/__tests__/article.crud.community.test.js
@@ -67,9 +67,22 @@ describe("Article CRUD Service", () => {
               commentId: 1,
               content: "Test Comment",
               isAnonymous: false,
-              articleCommentLikes: [
-                { likedUserId: 7 }, // 댓글 좋아요
-              ],
+              status: "active",
+              articleCommentLikes: [{ likedUserId: 7 }], // 댓글 좋아요
+            },
+          },
+          {
+            dataValues: {
+              author: {
+                userId: 6,
+                nickname: "CommentUser2",
+                profileImage: "commentProfile2.jpg",
+              },
+              commentId: 2,
+              content: "Test Comment 2",
+              isAnonymous: false,
+              status: "deleted",
+              articleCommentLikes: [{ likedUserId: 7 }], // 댓글 좋아요
             },
           },
         ],
@@ -81,7 +94,6 @@ describe("Article CRUD Service", () => {
           { likedUserId: 6 }, // 게시글 좋아요
         ],
       });
-    
 
       const article = await articleCrudService.getArticleById({
         communityId: 4,
@@ -89,30 +101,36 @@ describe("Article CRUD Service", () => {
       });
 
       // 반환된 데이터 검증
-  expect(article.articleId).toBe(1);
-  expect(article.communityId).toBe(4);
-  expect(article.title).toBe("Test Article");
-  expect(article.content).toBe("Test Content");
-  expect(article.isAnonymous).toBe(false);
+      expect(article.articleId).toBe(1);
+      expect(article.communityId).toBe(4);
+      expect(article.title).toBe("Test Article");
+      expect(article.content).toBe("Test Content");
+      expect(article.isAnonymous).toBe(false);
 
-  // 작성자 정보 검증
-  expect(article.authorInfo.userId).toBe(3);
-  expect(article.authorInfo.nickname).toBe("User1");
+      // 작성자 정보 검증
+      expect(article.authorInfo.userId).toBe(3);
+      expect(article.authorInfo.nickname).toBe("User1");
 
-  // 댓글 정보 검증
-  expect(article.articleComments[0].commentId).toBe(1);
-  expect(article.articleComments[0].content).toBe("Test Comment");
-  expect(article.articleComments[0].authorInfo.userId).toBe(5);
-  expect(article.articleComments[0].isLikedByUser).toBe(false); // userId가 7과 다르므로 false
-  expect(article.articleComments[0].commentLikesCount).toBe(1); // 좋아요 개수 확인
+      // 댓글 정보 검증
+      expect(article.articleComments[0].commentId).toBe(1);
+      expect(article.articleComments[0].content).toBe("Test Comment");
+      expect(article.articleComments[0].authorInfo.userId).toBe(5);
+      expect(article.articleComments[0].isLikedByUser).toBe(false); // userId가 7과 다르므로 false
+      expect(article.articleComments[0].commentLikesCount).toBe(1); // 좋아요 개수 확인
 
-  // 이미지 검증
-  expect(article.articleImages[0].imageUrl).toContain("image1.jpg");
-  expect(article.articleImages[1].imageUrl).toContain("image2.jpg");
+      // 삭제된 댓글 정보 검증
+      expect(article.articleComments[1].commentId).toBe(2);
+      expect(article.articleComments[1].content).toBe("");
+      expect(article.articleComments[1].authorInfo).toBeNull();
+      expect(article.articleComments[1].commentLikesCount).toBe(0); // 좋아요 개수 검증
 
-  // 좋아요 및 댓글 개수 검증
-  expect(article.articleLikesCount).toBe(1); // 좋아요 개수 확인
-  expect(article.commentsCount).toBe(1); // 댓글 개수 확인
+      // 이미지 검증
+      expect(article.articleImages[0].imageUrl).toContain("image1.jpg");
+      expect(article.articleImages[1].imageUrl).toContain("image2.jpg");
+
+      // 좋아요 및 댓글 개수 검증
+      expect(article.articleLikesCount).toBe(1); // 좋아요 개수 확인
+      expect(article.commentsCount).toBe(2); // 댓글 개수 확인
     });
 
     it("should throw NotExistsError if the article does not exist", async () => {

--- a/__tests__/comment.community.test.js
+++ b/__tests__/comment.community.test.js
@@ -57,7 +57,8 @@ describe("Comment Service", () => {
 
   describe("updateComment()", () => {
     it("should successfully update a comment", async () => {
-      const mockUpdate = jest.fn().mockResolvedValue(true); // update 메서드 Mock 설정
+      // 메서드가 잘 호출되었는지 확인하기 위해 mockUpdate 함수 생성
+      const mockUpdate = jest.fn().mockResolvedValue(true); // mockUpdate 메서드 반환값 설정
 
       models.ArticleComments.findOne.mockResolvedValue({
         commentId: 1,
@@ -120,13 +121,16 @@ describe("Comment Service", () => {
   });
 
   describe("deleteComment()", () => {
-    it("should successfully delete a comment", async () => {
+    it("should successfully delete a comment without replies", async () => {
+      // destroy 메서드에는 반환값이 없으므로 이를 추적하기 위해 mockDestroy 함수를 생성
       const mockDestroy = jest.fn().mockResolvedValue(true);
       models.ArticleComments.findOne.mockResolvedValue({
         commentId: 1,
         authorId: 1001,
         destroy: mockDestroy,
       });
+
+      models.ArticleComments.count.mockResolvedValue(0); // 대댓글이 없는 경우
 
       await commentService.deleteComment({
         communityId: 4,
@@ -139,6 +143,61 @@ describe("Comment Service", () => {
         where: { articleId: 1, commentId: 1 },
       });
       expect(mockDestroy).toHaveBeenCalled();
+    });
+
+    it("should soft delete a comment with replies", async () => {
+      models.ArticleComments.findOne.mockResolvedValue({
+        commentId: 1,
+        authorId: 1001,
+      });
+
+      models.ArticleComments.count.mockResolvedValue(2); // 대댓글이 2개 있는 경우
+      const mockUpdate = jest.spyOn(models.ArticleComments, "update");
+
+      await commentService.softDeleteComment({
+        communityId: 4,
+        articleId: 1,
+        commentId: 1,
+        authorId: 1001,
+      });
+
+      expect(models.ArticleComments.findOne).toHaveBeenCalledWith({
+        where: { articleId: 1, commentId: 1 },
+      });
+      expect(mockUpdate).toHaveBeenCalledWith(
+        { status: "deleted" },
+        { where: { commentId: 1 } }
+      );
+    });
+
+    it("should delete a parent comment if it is soft-deleted and only has one reply", async () => {
+      models.ArticleComments.findOne
+        .mockResolvedValueOnce({
+          commentId: 2,
+          authorId: 1001,
+          parentCommentId: 1,
+        })
+        .mockResolvedValueOnce({
+          commentId: 1,
+          status: "deleted",
+        });
+
+      models.ArticleComments.count.mockResolvedValue(1); // 부모 댓글에 대댓글 1개만 존재하는 경우
+
+      // destroy 메서드에는 반환값이 없으므로 이를 추적하기 위해 mockDestroy 함수를 생성
+      const mockDestroy = jest.fn().mockResolvedValue(true);
+      models.ArticleComments.destroy = mockDestroy;
+
+      await commentService.deleteReply({
+        articleId: 1,
+        commentId: 2,
+        parentCommentId: 1,
+        authorId: 1001,
+      });
+
+      expect(mockDestroy).toHaveBeenCalledWith({
+        where: { commentId: 1 },
+      });
     });
 
     it("should throw NotExistsError if the comment does not exist", async () => {
@@ -252,33 +311,37 @@ describe("Comment Service", () => {
           },
         ],
       });
-    
+
       const result = await commentService.getComments({
         communityId: 4,
         articleId: 1,
         userId: 10, // 현재 사용자 ID (좋아요 여부 확인용)
       });
-    
+
       // 반환된 댓글 개수 검증
       expect(result.comments).toHaveLength(2);
-    
+
       // 첫 번째 댓글 검증
       expect(result.comments[0].commentId).toBe(1);
       expect(result.comments[0].content).toBe("Test Comment");
       expect(result.comments[0].isAnonymous).toBe(false);
       expect(result.comments[0].authorInfo.userId).toBe(5);
       expect(result.comments[0].authorInfo.nickname).toBe("CommentUser1");
-      expect(result.comments[0].authorInfo.profileImage).toContain("commentProfile1.jpg");
+      expect(result.comments[0].authorInfo.profileImage).toContain(
+        "commentProfile1.jpg"
+      );
       expect(result.comments[0].isLikedByUser).toBe(true); // 현재 사용자(10)가 좋아요를 눌렀음
       expect(result.comments[0].commentLikesCount).toBe(1); // 좋아요 개수 검증
-    
+
       // 두 번째 댓글 검증
       expect(result.comments[1].commentId).toBe(2);
       expect(result.comments[1].content).toBe("Another Comment");
       expect(result.comments[1].isAnonymous).toBe(true);
       expect(result.comments[1].authorInfo.userId).toBe(6);
       expect(result.comments[1].authorInfo.nickname).toBe("CommentUser2");
-      expect(result.comments[1].authorInfo.profileImage).toBe("commentProfile2.jpg");
+      expect(result.comments[1].authorInfo.profileImage).toBe(
+        "commentProfile2.jpg"
+      );
       expect(result.comments[1].isLikedByUser).toBe(false); // 좋아요 없음
       expect(result.comments[1].commentLikesCount).toBe(0); // 좋아요 개수 검증
     });

--- a/__tests__/comment.community.test.js
+++ b/__tests__/comment.community.test.js
@@ -290,6 +290,7 @@ describe("Comment Service", () => {
               },
               commentId: 1,
               content: "Test Comment",
+              status: "active",
               isAnonymous: false,
               articleCommentLikes: [
                 { likedUserId: 10 }, // 첫 번째 댓글에 좋아요 1개
@@ -305,8 +306,25 @@ describe("Comment Service", () => {
               },
               commentId: 2,
               content: "Another Comment",
+              status: "active",
               isAnonymous: true,
               articleCommentLikes: [], // 두 번째 댓글에 좋아요 없음
+            },
+          },
+          {
+            dataValues: {
+              author: {
+                userId: 7,
+                nickname: "CommentUser3",
+                profileImage: "commentProfile3.jpg",
+              },
+              commentId: 3,
+              content: "The Other Comment",
+              status: "deleted",
+              isAnonymous: false,
+              articleCommentLikes: [
+                { likedUserId: 10 }, // 세 번째 댓글에 좋아요 1개
+              ], // 두 번째 댓글에 좋아요 없음
             },
           },
         ],
@@ -319,7 +337,7 @@ describe("Comment Service", () => {
       });
 
       // 반환된 댓글 개수 검증
-      expect(result.comments).toHaveLength(2);
+      expect(result.comments).toHaveLength(3);
 
       // 첫 번째 댓글 검증
       expect(result.comments[0].commentId).toBe(1);
@@ -342,6 +360,13 @@ describe("Comment Service", () => {
       expect(result.comments[1].authorInfo.profileImage).toBe(
         "commentProfile2.jpg"
       );
+      expect(result.comments[1].isLikedByUser).toBe(false); // 좋아요 없음
+      expect(result.comments[1].commentLikesCount).toBe(0); // 좋아요 개수 검증
+
+      // 세 번째 댓글 검증 (삭제된 댓글)
+      expect(result.comments[2].commentId).toBe(3);
+      expect(result.comments[2].content).toBe("");
+      expect(result.comments[2].authorInfo).toBeNull();
       expect(result.comments[1].isLikedByUser).toBe(false); // 좋아요 없음
       expect(result.comments[1].commentLikesCount).toBe(0); // 좋아요 개수 검증
     });

--- a/__tests__/comment.community.test.js
+++ b/__tests__/comment.community.test.js
@@ -367,8 +367,7 @@ describe("Comment Service", () => {
       expect(result.comments[2].commentId).toBe(3);
       expect(result.comments[2].content).toBe("");
       expect(result.comments[2].authorInfo).toBeNull();
-      expect(result.comments[1].isLikedByUser).toBe(false); // 좋아요 없음
-      expect(result.comments[1].commentLikesCount).toBe(0); // 좋아요 개수 검증
+      expect(result.comments[2].commentLikesCount).toBe(0); // 좋아요 개수 검증
     });
 
     it("should throw NotExistsError if the article does not exist", async () => {

--- a/controllers/community/article.crud.community.controller.js
+++ b/controllers/community/article.crud.community.controller.js
@@ -23,10 +23,11 @@ export const createCommunity = async (req, res, next) => {
 export const getArticleById = async (req, res, next) => {
   try {
     const { communityId, articleId } = req.params; // URL에서 communityId, articleId 추출
-
+    const userId = req.user ? req.user.userId : null;  // JWT에서 userId 추출 - 로그인되지 않은 경우를 위한 null
     const article = await articleCrudService.getArticleById({
       communityId,
       articleId,
+      userId,
     }); // 게시글 조회
 
     // 게시글이 존재하는 경우

--- a/controllers/community/article.read.community.controller.js
+++ b/controllers/community/article.read.community.controller.js
@@ -9,6 +9,7 @@ export const getArticles = async (req, res, next) => {
   try {
     articleReadService.validateArticleQuery(req.query);
     const { communityId, limit, cursor, query } = req.query; // 쿼리 파라미터에서 limit와 cursor 추출
+    const userId = req.user ? req.user.userId : null;  // JWT에서 userId 추출 - 로그인되지 않은 경우를 위한 null
 
     logger.debug("게시글 목록 조회", {
       action: "article:getArticles",
@@ -29,7 +30,8 @@ export const getArticles = async (req, res, next) => {
       await articleReadService.getArticles(
         communityId,
         query,
-        paginationOptions
+        paginationOptions,
+        userId
       );
 
     // 게시글이 없는 경우

--- a/controllers/community/comment.community.controller.js
+++ b/controllers/community/comment.community.controller.js
@@ -104,6 +104,7 @@ export const createCommentReply = async (req, res, next) => {
 export const getComments = async (req, res, next) => {
   try {
     const { communityId, articleId } = req.query; // URL에서 communityId, articleId 추출
+    const userId = req.user ? req.user.userId : null; // JWT에서 userId 추출 - 로그인되지 않은 경우를 위한 null
 
     if (communityId === undefined || articleId === undefined) {
       throw new InvalidQueryError(
@@ -121,6 +122,7 @@ export const getComments = async (req, res, next) => {
     const { comments } = await commentService.getComments({
       communityId,
       articleId,
+      userId,
     }); // 댓글 조회
 
     if (comments && comments.length === 0) {

--- a/routes/community.router.js
+++ b/routes/community.router.js
@@ -10,7 +10,7 @@ import * as articleAggregateController from "../controllers/community/article.ag
 import * as articleValidator from "../utils/validators/community/article.validators.js";
 
 // 사용자 인증 미들웨어 (추후 네임스페이스 방식으로 변경 필요)
-import { authenticateAccessToken } from "../middleware/authenticate.jwt.js";
+import { authenticateAccessToken, autheticateAccessTokenIfExists } from "../middleware/authenticate.jwt.js";
 import * as fileUploadMiddleware from "../middleware/uploader.js"; // 사진 업로드 미들웨어
 import { validateRequestBody } from "../middleware/validate.js";
 import * as aritcleSchema from "../utils/validators/community/article.validators.js";
@@ -33,7 +33,7 @@ router.post(
 */
 
 // communityId에 해당하는 게시판의 게시글들을 가져옵니다, 좋아요 누른 게시글만 가져올 수도 있습니다
-router.get("/", authenticateAccessToken, articleReadController.getArticles);
+router.get("/", autheticateAccessTokenIfExists, articleReadController.getArticles);
 router.get(
   "/article/like",
   authenticateAccessToken,

--- a/routes/community.router.js
+++ b/routes/community.router.js
@@ -10,7 +10,10 @@ import * as articleAggregateController from "../controllers/community/article.ag
 import * as articleValidator from "../utils/validators/community/article.validators.js";
 
 // 사용자 인증 미들웨어 (추후 네임스페이스 방식으로 변경 필요)
-import { authenticateAccessToken, autheticateAccessTokenIfExists } from "../middleware/authenticate.jwt.js";
+import {
+  authenticateAccessToken,
+  autheticateAccessTokenIfExists,
+} from "../middleware/authenticate.jwt.js";
 import * as fileUploadMiddleware from "../middleware/uploader.js"; // 사진 업로드 미들웨어
 import { validateRequestBody } from "../middleware/validate.js";
 import * as aritcleSchema from "../utils/validators/community/article.validators.js";
@@ -33,7 +36,11 @@ router.post(
 */
 
 // communityId에 해당하는 게시판의 게시글들을 가져옵니다, 좋아요 누른 게시글만 가져올 수도 있습니다
-router.get("/", autheticateAccessTokenIfExists, articleReadController.getArticles);
+router.get(
+  "/",
+  autheticateAccessTokenIfExists,
+  articleReadController.getArticles
+);
 router.get(
   "/article/like",
   authenticateAccessToken,
@@ -126,7 +133,11 @@ router.delete(
 */
 
 // communityId에 해당하는 게시판의 articleId에 해당하는 게시글의 댓글 정보를 가져옵니다.
-router.get("/articles/comments", commentController.getComments);
+router.get(
+  "/articles/comments",
+  autheticateAccessTokenIfExists,
+  commentController.getComments
+);
 
 // article에 댓글을 추가합니다.
 router.post(

--- a/routes/community.router.js
+++ b/routes/community.router.js
@@ -57,6 +57,7 @@ router.get(
 // communityId에 해당하는 게시판의 articleId에 해당하는 게시글을 가져옵니다
 router.get(
   "/:communityId/articles/:articleId",
+  autheticateAccessTokenIfExists,
   articleCrudController.getArticleById
 );
 

--- a/routes/community.router.js
+++ b/routes/community.router.js
@@ -33,7 +33,7 @@ router.post(
 */
 
 // communityId에 해당하는 게시판의 게시글들을 가져옵니다, 좋아요 누른 게시글만 가져올 수도 있습니다
-router.get("/", articleReadController.getArticles);
+router.get("/", authenticateAccessToken, articleReadController.getArticles);
 router.get(
   "/article/like",
   authenticateAccessToken,

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -108,26 +108,29 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     sequence: image.sequence,
   }));
 
-  // 게시글에 대한 좋아요 여부 추가
+  // 게시글 좋아요 여부 및 좋아요 개수
   const isArticleLikedByUser = userId
     ? data.articleLikes.some((like) => like.likedUserId === userId)
     : false;
+  const articleLikesCount = data.articleLikes.length;
 
-  // 댓글 정보에 좋아요 여부 및 작성자 정보 추가
+  // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
   const transformedComments = data.articleComments.map((comment) => {
     const { author, articleCommentLikes, ...commentData } = comment.dataValues;
 
-    // 댓글 좋아요 여부 확인
     const isCommentLikedByUser = userId
       ? articleCommentLikes.some((like) => like.likedUserId === userId)
       : false;
+    const commentLikesCount = articleCommentLikes.length;
 
     return {
       authorInfo: author,
       isLikedByUser: isCommentLikedByUser,
+      commentLikesCount,  // 댓글 좋아요 개수
       ...commentData,
     };
   });
+
 
   // 게시글의 작성자 정보 및 익명 처리
   const { author, ...articleData } = data.dataValues;
@@ -154,6 +157,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
   const ret = {
     authorInfo: transformedAuthorInfo,
     isLikedByUser: isArticleLikedByUser,
+    articleLikesCount,
     ...articleData,
     articleComments: transformedComments,
     articleImages: transformedImages,

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -71,7 +71,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
             attributes: ["userId", "nickname", "profileImage"], // 댓글 작성자의 정보만 선택
           },
           {
-            model: models.ArticleCommentLikes,  // 댓글 좋아요 모델 추가
+            model: models.ArticleCommentLikes, // 댓글 좋아요 모델 추가
             as: "articleCommentLikes",
             attributes: ["likedUserId"], // 좋아요를 누른 사용자 ID
           },
@@ -83,7 +83,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
         attributes: ["imageUrl", "sequence"],
       },
       {
-        model: models.ArticleLikes,  // 게시글 좋아요 모델 추가
+        model: models.ArticleLikes, // 게시글 좋아요 모델 추가
         as: "articleLikes",
         attributes: ["likedUserId"],
       },
@@ -126,14 +126,16 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     return {
       authorInfo: author,
       isLikedByUser: isCommentLikedByUser,
-      commentLikesCount,  // 댓글 좋아요 개수
+      commentLikesCount, // 댓글 좋아요 개수
       ...commentData,
     };
   });
 
+  // 댓글 개수 계산
+  const commentsCount = data.articleComments.length;
 
   // 게시글의 작성자 정보 및 익명 처리
-  const { author, ...articleData } = data.dataValues;
+  const { author, articleLikes, ...articleData } = data.dataValues;
   let transformedAuthorInfo = author;
 
   if (articleData.isAnonymous === true) {
@@ -158,6 +160,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     authorInfo: transformedAuthorInfo,
     isLikedByUser: isArticleLikedByUser,
     articleLikesCount,
+    commentsCount,
     ...articleData,
     articleComments: transformedComments,
     articleImages: transformedImages,

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -116,17 +116,23 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
 
   // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
   const transformedComments = data.articleComments.map((comment) => {
-    const { author, articleCommentLikes, ...commentData } = comment.dataValues;
+    const { author, articleCommentLikes, status, content, ...commentData } =
+      comment.dataValues;
 
     const isCommentLikedByUser = userId
       ? articleCommentLikes.some((like) => like.likedUserId === userId)
       : false;
     const commentLikesCount = articleCommentLikes.length;
 
+    // status가 'deleted'인 경우 content를 빈 문자열로 설정
+    const processedContent = status === "deleted" ? "" : content;
+
     return {
-      authorInfo: author,
+      authorInfo: status === "deleted" ? null : author,
       isLikedByUser: isCommentLikedByUser,
-      commentLikesCount, // 댓글 좋아요 개수
+      commentLikesCount: status === "deleted" ? 0 : commentLikesCount, 
+      content: processedContent,
+        status, // 상태 정보도 포함해 응답
       ...commentData,
     };
   });

--- a/services/community/article.read.community.service.js
+++ b/services/community/article.read.community.service.js
@@ -37,7 +37,8 @@ export const validateArticleQuery = (queries) => {
 export const getArticles = async (
   communityId,
   query,
-  { limit, cursor = null }
+  { limit, cursor = null },
+  userId
 ) => {
   // 게시판 및 게시글 조회
   const community = await models.Communities.findOne({
@@ -124,8 +125,19 @@ export const getArticles = async (
   // 좋아요, 댓글 수 및 썸네일만을 반환하도록 가공
   articles.map((article) => {
     article = article.dataValues;
+    
+    // 좋아요 여부 확인
+    if (userId) {
+      article.isLikedByUser = article.articleLikes.some(
+        (like) => like.likedUserId === userId
+      );
+    } else {
+      article.isLikedByUser = false;  // 비로그인 사용자는 항상 false
+    }
+
     article.articleComments = article.articleComments.length; // 댓글 개수만 추출
     article.articleLikes = article.articleLikes.length; // 좋아요 개수만 추출
+    
     if (article.articleImages.length > 0) {
       article.articleImages = addBaseUrl(
         article.articleImages[0].dataValues.imageUrl

--- a/services/community/comment.community.service.js
+++ b/services/community/comment.community.service.js
@@ -208,22 +208,22 @@ export const getComments = async ({ communityId, articleId, userId }) => {
     throw new NotExistsError("게시글이 존재하지 않습니다");
   }
 
-  // 댓글 정보에 좋아요 여부 및 작성자 정보 추가
+  // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
   const transformedComments = articleWithComments.articleComments.map((comment) => {
     const { author, articleCommentLikes, ...commentData } = comment.dataValues;
 
-    // 댓글 좋아요 여부 확인
     const isCommentLikedByUser = userId
       ? articleCommentLikes.some((like) => like.likedUserId === userId)
       : false;
+    const commentLikesCount = articleCommentLikes.length;
 
     return {
       authorInfo: author,
       isLikedByUser: isCommentLikedByUser,
+      commentLikesCount, // 댓글 좋아요 개수
       ...commentData,
     };
   });
-
   return {
     comments: transformedComments,
   };

--- a/services/community/comment.community.service.js
+++ b/services/community/comment.community.service.js
@@ -311,7 +311,7 @@ export const getComments = async ({ communityId, articleId, userId }) => {
   // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
   const transformedComments = articleWithComments.articleComments.map(
     (comment) => {
-      const { author, articleCommentLikes, ...commentData } =
+      const { author, articleCommentLikes, status, content, ...commentData } =
         comment.dataValues;
 
       const isCommentLikedByUser = userId
@@ -319,10 +319,15 @@ export const getComments = async ({ communityId, articleId, userId }) => {
         : false;
       const commentLikesCount = articleCommentLikes.length;
 
+      // status가 'deleted'인 경우 content를 빈 문자열로 설정
+      const processedContent = status === "deleted" ? "" : content;
+
       return {
-        authorInfo: author,
+        authorInfo: status === "deleted" ? null : author, // 삭제된 경우 작성자 정보 숨김
         isLikedByUser: isCommentLikedByUser,
-        commentLikesCount, // 댓글 좋아요 개수
+        commentLikesCount: status === "deleted" ? 0 : commentLikesCount,
+        content: processedContent,
+        status, // 상태 정보도 포함해 응답
         ...commentData,
       };
     }

--- a/services/community/comment.community.service.js
+++ b/services/community/comment.community.service.js
@@ -99,10 +99,19 @@ export const updateComment = async ({
 };
 
 /**
- * communityId, articleId, commentId에 해당하는 댓글을 삭제합니다.
+ * 대댓글이 달려있는지 확인합니다.
  */
-export const deleteComment = async ({
-  communityId, // 현재는 사용하지는 않음
+export const hasReplies = async (commentId) => {
+  const replyCount = await models.ArticleComments.count({
+    where: { parent_comment_id: commentId },
+  });
+  return replyCount > 0;
+};
+
+/**
+ * 댓글이 존재 여부와 댓글 작성자 여부를 확인합니다.
+ */
+export const validateAndFindComment = async ({
   articleId,
   commentId,
   authorId,
@@ -115,7 +124,7 @@ export const deleteComment = async ({
     },
   });
 
-  if (!comment) {
+  if (!comment || comment.status === "deleted") {
     logger.error(
       `[deleteComment] 댓글이 존재하지 않음 - commentId: ${commentId}`
     );
@@ -131,8 +140,37 @@ export const deleteComment = async ({
     throw new NotAllowedError("댓글 작성자만 삭제할 수 있습니다");
   }
 
+  return comment;
+};
+/**
+ * communityId, articleId, commentId에 해당하는 댓글을 삭제합니다.
+ */
+export const deleteComment = async ({ articleId, commentId, authorId }) => {
+  // 댓글 조회 및 작성자 확인
+  const comment = await validateAndFindComment({
+    articleId,
+    commentId,
+    authorId,
+  });
   // 댓글 삭제
   await comment.destroy();
+};
+
+/**
+ * communityId, articleId, commentId에 해당하는 댓글의 status를 "deleted"로 변경합니다
+ */
+export const softDeleteComment = async ({ articleId, commentId, authorId }) => {
+  // 댓글 조회 및 작성자 확인
+  const comment = await validateAndFindComment({
+    articleId,
+    commentId,
+    authorId,
+  });
+  // 댓글 상태를 "deleted"로 변경
+  await models.ArticleComments.update(
+    { status: "deleted" },
+    { where: { comment_id: commentId } }
+  );
 };
 
 /**
@@ -209,21 +247,24 @@ export const getComments = async ({ communityId, articleId, userId }) => {
   }
 
   // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
-  const transformedComments = articleWithComments.articleComments.map((comment) => {
-    const { author, articleCommentLikes, ...commentData } = comment.dataValues;
+  const transformedComments = articleWithComments.articleComments.map(
+    (comment) => {
+      const { author, articleCommentLikes, ...commentData } =
+        comment.dataValues;
 
-    const isCommentLikedByUser = userId
-      ? articleCommentLikes.some((like) => like.likedUserId === userId)
-      : false;
-    const commentLikesCount = articleCommentLikes.length;
+      const isCommentLikedByUser = userId
+        ? articleCommentLikes.some((like) => like.likedUserId === userId)
+        : false;
+      const commentLikesCount = articleCommentLikes.length;
 
-    return {
-      authorInfo: author,
-      isLikedByUser: isCommentLikedByUser,
-      commentLikesCount, // 댓글 좋아요 개수
-      ...commentData,
-    };
-  });
+      return {
+        authorInfo: author,
+        isLikedByUser: isCommentLikedByUser,
+        commentLikesCount, // 댓글 좋아요 개수
+        ...commentData,
+      };
+    }
+  );
   return {
     comments: transformedComments,
   };


### PR DESCRIPTION
### 진행한 작업
- [x] 댓글 삭제 시 대댓글이 있는 경우 status만 deleted로 변경
- [x] 대댓글 삭제 방식 수정
- [x] 댓글 조회 시 deleted comment인 경우 content를 비워서 보내기
- [x] `deleteComment()` 테스트 코드 수정
- [x] `getArticleById()`, `getComments()` 테스트 코드 수정
- [x] 노션에 수정사항 반영

-----

**⚠️ 댓글 삭제 로직에 대하여 ⚠️**
1. 댓글인 경우
    1. 대댓글이 없는 댓글일 경우: DB에서 삭제
    2. 대댓글이 있는 댓글일 경우: status를 deleted로 변경
2. 대댓글인 경우
    1. 부모 댓글이 삭제되지 않은 경우: DB에서 삭제
    2. 부모 댓글이 삭제되었지만 자신이 유일한 대댓글은 아닌 경우: DB에서 삭제
    3. 부모 댓글이 삭제되었고 자신이 마지막 남은 대댓글인 경우: 부모 댓글을 DB에서 삭제 (DB 제약에 따라 해당 대댓글도 같이 삭제됨)
