### PR TITLE
커뮤니티, 공지사항(조회), Admin 관련 점검

### DIFF
--- a/__tests__/comment.like.community.test.js
+++ b/__tests__/comment.like.community.test.js
@@ -82,10 +82,8 @@ describe("Comment Like Service", () => {
       const mockLike = { destroy: jest.fn() };
 
       // 댓글과 좋아요 정보를 Mock으로 설정
-      models.ArticleComments.findOne.mockResolvedValue({
-        commentId: 1,
-        articleCommentLikes: [mockLike],
-      });
+      models.ArticleComments.findOne.mockResolvedValue({ commentId: 1 });
+      models.ArticleCommentLikes.findOne.mockResolvedValue(mockLike);
 
       await commentLikeService.unlikeComment({
         communityId: 4,
@@ -97,14 +95,9 @@ describe("Comment Like Service", () => {
       // 댓글 및 좋아요가 정상적으로 조회되었는지 확인
       expect(models.ArticleComments.findOne).toHaveBeenCalledWith({
         where: { articleId: 1, commentId: 1 },
-        include: [
-          {
-            model: models.ArticleCommentLikes,
-            as: "articleCommentLikes",
-            where: { likedUserId: 1001 },
-            required: false,
-          },
-        ],
+      });
+      expect(models.ArticleCommentLikes.findOne).toHaveBeenCalledWith({
+        where: { commentId: 1, likedUserId: 1001 },
       });
 
       // 좋아요가 정상적으로 삭제되었는지 확인
@@ -126,11 +119,9 @@ describe("Comment Like Service", () => {
     });
 
     it("should throw NotExistsError if the like is already removed", async () => {
-      // 댓글에는 좋아요가 없는 상태로 설정
-      models.ArticleComments.findOne.mockResolvedValue({
-        commentId: 1,
-        articleCommentLikes: [],
-      });
+      // 좋아요가 없는 상태로 설정
+      models.ArticleComments.findOne.mockResolvedValue({ commentId: 1 });
+      models.ArticleCommentLikes.findOne.mockResolvedValue(null);
 
       await expect(
         commentLikeService.unlikeComment({

--- a/controllers/community/article.crud.community.controller.js
+++ b/controllers/community/article.crud.community.controller.js
@@ -23,8 +23,8 @@ export const createCommunity = async (req, res, next) => {
 export const getArticleById = async (req, res, next) => {
   try {
     const { communityId, articleId } = req.params; // URL에서 communityId, articleId 추출
-    const userId = req.user ? req.user.userId : null;  // JWT에서 userId 추출 - 로그인되지 않은 경우를 위한 null
-    const article = await articleCrudService.getArticleById({
+    const userId = req.user ? req.user.userId : null; // JWT에서 userId 추출 - 로그인되지 않은 경우를 위한 null
+    const { article } = await articleCrudService.getArticleById({
       communityId,
       articleId,
       userId,

--- a/controllers/community/article.crud.community.controller.js
+++ b/controllers/community/article.crud.community.controller.js
@@ -47,20 +47,14 @@ export const createArticle = async (req, res, next) => {
     // 입력 형식 검증은 완료된 상태로 들어온다고 가정.
     // 사용자 인증 검증
     const { communityId } = req.params; // URL에서 communityId 추출
-    const { title, content, isAnonymous } = JSON.parse(req.body.data); // Request body에서 title, content 추출
     const authorId = req.user.userId; // JWT에서 사용자 ID 추출
-
-    // 업로드된 파일 정보 추출
-    const uploadedFiles = req.files?.article_images || [];
 
     // 게시글 생성
     await articleCrudService.createArticle({
       communityId,
       authorId,
-      title,
-      content,
-      isAnonymous,
-      imagePaths: parseImagePaths(uploadedFiles),
+      requestBody: req.body.data,
+      uploadedFiles: req.files?.article_images || [],
     });
 
     // TODO: 사진 업로드 안 되었을 시 적용할 transaction 처리

--- a/controllers/community/report.community.controller.js
+++ b/controllers/community/report.community.controller.js
@@ -13,7 +13,8 @@ export const reportArticle = async (req, res, next) => {
       throw new InvalidInputError("신고 사유를 입력해주세요.");
     }
 
-    const { articleReport } = await reportService.reportArticle({
+    const { newReport } = await reportService.reportTarget({
+      targetType: "article",
       communityId,
       articleId,
       reportedUserId,
@@ -22,7 +23,6 @@ export const reportArticle = async (req, res, next) => {
 
     res.status(201).success({
       message: "게시글 신고 성공",
-      articleReport,
     });
   } catch (error) {
     logError(error);
@@ -39,7 +39,8 @@ export const reportComment = async (req, res, next) => {
       throw new InvalidInputError("신고 사유를 입력해주세요.");
     }
 
-    const { commentReport } = await reportService.reportComment({
+    const { newReport } = await reportService.reportTarget({
+      targetType: "comment",
       communityId,
       articleId,
       commentId,
@@ -49,7 +50,6 @@ export const reportComment = async (req, res, next) => {
 
     res.status(201).success({
       message: "댓글 신고 성공",
-      commentReport,
     });
   } catch (error) {
     logError(error);

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -163,7 +163,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     });
   }
 
-  const ret = {
+  const article = {
     authorInfo: transformedAuthorInfo,
     isLikedByUser: isArticleLikedByUser,
     articleLikesCount,
@@ -173,7 +173,7 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     articleImages: transformedImages,
   };
 
-  return ret;
+  return { article };
 };
 
 /**

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -11,6 +11,7 @@ import {
   deleteLocalFile,
   isEditInputCorrect,
 } from "../../utils/upload/uploader.object.js";
+import { parseImagePaths } from "../../utils/upload/uploader.object.js";
 
 export const createCommunity = async ({ communityName }) => {
   // 게시판 생성
@@ -130,9 +131,9 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     return {
       authorInfo: status === "deleted" ? null : author,
       isLikedByUser: isCommentLikedByUser,
-      commentLikesCount: status === "deleted" ? 0 : commentLikesCount, 
+      commentLikesCount: status === "deleted" ? 0 : commentLikesCount,
       content: processedContent,
-        status, // 상태 정보도 포함해 응답
+      status, // 상태 정보도 포함해 응답
       ...commentData,
     };
   });
@@ -181,27 +182,26 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
 export const createArticle = async ({
   communityId,
   authorId,
-  title,
-  content,
-  isAnonymous = true,
-  imagePaths,
+  requestBody,
+  uploadedFiles,
 }) => {
+  const { title, content, isAnonymous } = JSON.parse(requestBody);
   // 게시판 검색
   const community = await models.Communities.findOne({
     where: {
       communityId,
     },
   });
-
   // 테스트 코드에서 Mock으로 처리하는 부분은 DB의 FK 제약을 테스트하기 어려우므로 이 부분 다시 추가
   if (!community) {
     throw new NotExistsError("존재하지 않는 게시판입니다.");
   }
+  // 이미지 경로 파싱
+  const imagePaths = parseImagePaths(uploadedFiles);
 
   // 게시글 생성
   let article;
   let articleImageData;
-
   /*
     try-catch 블록 외부에서 article 선언
     try-catch 블록 내부에서 article을 생성하고 반환하면

--- a/services/community/article.read.community.service.js
+++ b/services/community/article.read.community.service.js
@@ -32,6 +32,38 @@ export const validateArticleQuery = (queries) => {
 };
 
 /**
+ *  게시글의 썸네일 정보를 가공합니다.
+ */
+const getThumbnail = (articleImages) => {
+  if (articleImages.length > 0) {
+    const thumbnail = addBaseUrl(articleImages[0].dataValues.imageUrl);
+    return thumbnail;
+  }
+  return null;
+};
+
+/**
+ *  게시글의 작성자 정보를 가공하고 불필요한 필드를 제거합니다.
+ */
+const getAuthorInfo = (article, isAnonymous) => {
+  if (isAnonymous) {
+    delete article.author.dataValues;
+    return { nickname: null, profileImage: null, authorId: null };
+  }
+
+  const author = article.author.dataValues;
+  const authorInfo = {
+    nickname: author.nickname,
+    profileImage: addBaseUrl(author.profileImage),
+    authorId: author.userId,
+  };
+
+  // 불필요한 필드 제거
+  delete article.author.dataValues;
+
+  return authorInfo;
+};
+/**
  * communityId에 해당하는 게시판의 게시글들을 가져옵니다
  */
 export const getArticles = async (
@@ -137,40 +169,9 @@ export const getArticles = async (
 
     article.articleComments = article.articleComments.length; // 댓글 개수만 추출
     article.articleLikes = article.articleLikes.length; // 좋아요 개수만 추출
-    
-    if (article.articleImages.length > 0) {
-      article.articleImages = addBaseUrl(
-        article.articleImages[0].dataValues.imageUrl
-      ); // 대표 이미지 URL
-      // dataValues가 빠져 있어서 오류 발생했었음
-    } else {
-      article.articleImages = null;
-    }
-    article.thumbnail = article.articleImages;
-    delete article.articleImages;
-
-    // 작성자 정보 처리
-    if (article.isAnonymous === true) {
-      // 익명 상태면 모든 작성자 정보를 null로 설정
-      // test 코드를 위해서 authorInfo 자체를 null로 보내는 것이 아닌 각각을 null로 설정
-      article.authorInfo = {
-        nickname: null,
-        profileImage: null,
-        authorId: null,
-      };
-      
-    } else {
-      article.author = article.author.dataValues;
-      article.author.profileImage = addBaseUrl(article.author.profileImage);
-
-      // author.userId를 authorId로 변경
-      article.author.authorId = article.author.userId;
-      delete article.author.userId;
-
-      // author를 authorInfo로 변경
-      article.authorInfo = article.author;
-    }
-    delete article.author;
+    article.thumbnail = getThumbnail(article.articleImages); // 썸네일 정보 추출
+    delete article.articleImages; // 불필요한 필드 제거
+    article.authorInfo = getAuthorInfo(article, article.isAnonymous); // 작성자 정보 추출
   });
 
   // 다음 커서 설정
@@ -255,39 +256,9 @@ export const getLikedArticles = async (userId, { limit, cursor = null }) => {
     article = article.dataValues;
     article.articleComments = article.articleComments.length; // 댓글 개수만 추출
     article.articleLikes = article.articleLikes.length; // 좋아요 개수만 추출
-    if (article.articleImages.length > 0) {
-      article.articleImages = addBaseUrl(
-        article.articleImages[0].dataValues.imageUrl
-      ); // 대표 이미지 URL
-      // dataValues가 빠져 있어서 오류 발생했었음
-    } else {
-      article.articleImages = null;
-    }
-    article.thumbnail = article.articleImages;
-    delete article.articleImages;
-
-    // 작성자 정보 처리
-    if (article.isAnonymous === true) {
-      // 익명 상태면 모든 작성자 정보를 null로 설정
-      // test 코드를 위해서 authorInfo 자체를 null로 보내는 것이 아닌 각각을 null로 설정
-      article.authorInfo = {
-        nickname: null,
-        profileImage: null,
-        authorId: null,
-      };
-      
-    } else {
-      article.author = article.author.dataValues;
-      article.author.profileImage = addBaseUrl(article.author.profileImage);
-
-      // author.userId를 authorId로 변경
-      article.author.authorId = article.author.userId;
-      delete article.author.userId;
-
-      // author를 authorInfo로 변경
-      article.authorInfo = article.author;
-    }
-    delete article.author;
+    article.thumbnail = getThumbnail(article.articleImages); // 썸네일 정보 추출
+    delete article.articleImages; // 불필요한 필드 제거
+    article.authorInfo = getAuthorInfo(article, article.isAnonymous); // 작성자 정보 추출
   });
 
   // 다음 커서 설정

--- a/services/community/comment.like.community.service.js
+++ b/services/community/comment.like.community.service.js
@@ -7,6 +7,24 @@ import models from "../../models/index.js";
 import logger from "../../utils/logger/logger.js";
 
 /**
+ * 댓글이 존재하는지 확인합니다.
+ */
+const checkCommentExists = async (articleId, commentId) => {
+  // 원래 ForeignKeyConstraintError를 처리하려 했지만, articleId에 대한 확인도 필요하여 이렇게 수정
+  const comment = await models.ArticleComments.findOne({
+    where: { articleId, commentId },
+  });
+
+  if (!comment) {
+    logger.error(
+      `[likeComment] 댓글이 존재하지 않음 - commentId: ${commentId}, articleId: ${articleId}`
+    );
+    throw new NotExistsError("해당 댓글이 존재하지 않습니다.");
+  }
+  return comment;
+};
+
+/**
  * 댓글 좋아요를 추가합니다
  */
 export const likeComment = async ({
@@ -15,20 +33,7 @@ export const likeComment = async ({
   commentId,
   likedUserId,
 }) => {
-  // 원래 ForeignKeyConstraintError를 처리하려 했지만, articleId에 대한 확인도 필요하여 이렇게 수정
-  const comment = await models.ArticleComments.findOne({
-    where: {
-      commentId,
-      articleId,
-    },
-  });
-
-  if (!comment) {
-    logger.error(
-      `[likeComment] 댓글이 존재하지 않음 - commentId: ${commentId}, articleId: ${articleId}`
-    );
-    throw new NotExistsError("해당 댓글이 존재하지 않습니다");
-  }
+  await checkCommentExists(articleId, commentId); // 댓글 존재 여부 확인
 
   let like;
   /* try-catch 블록 외부에서 like 선언
@@ -36,7 +41,6 @@ export const likeComment = async ({
   "like is not defined" 에러가 발생합니다.
   */
   try {
-    
     // 좋아요 추가 (Unique 제약 조건으로 중복 방지)
     like = await models.ArticleCommentLikes.create({
       commentId,
@@ -65,34 +69,14 @@ export const unlikeComment = async ({
   commentId,
   likedUserId,
 }) => {
-  // 댓글 조회
-  const comment = await models.ArticleComments.findOne({
-    where: {
-      articleId,
-      commentId,
-    },
-    include: [
-      {
-        model: models.ArticleCommentLikes,
-        as: "articleCommentLikes",
-        where: {
-          likedUserId,
-        },
-        required: false, // 좋아요가 없는 경우도 조회 가능하도록 설정
-      },
-    ],
+  await checkCommentExists(articleId, commentId); // 댓글 존재 여부 확인
+
+  // 좋아요 여부 확인
+  const like = await models.ArticleCommentLikes.findOne({
+    where: { commentId, likedUserId },
   });
-
-  // 댓글이 존재하지 않는 경우
-  if (!comment) {
-    logger.error(
-      `[unlikeComment] 댓글이 존재하지 않음 - commentId: ${commentId}`
-    );
-    throw new NotExistsError("댓글이 존재하지 않습니다"); // 404
-  }
-
   // 좋아요가 눌리지 않은 경우
-  if (comment.articleCommentLikes.length === 0) {
+  if (!like) {
     logger.error(
       `[unlikeComment] 이미 좋아요가 취소된 댓글 - commentId: ${commentId}, likedUserId: ${likedUserId}`
     );
@@ -100,8 +84,5 @@ export const unlikeComment = async ({
   }
 
   // 좋아요 삭제
-  await comment.articleCommentLikes[0].destroy();
-
-
-  return;
+  await like.destroy();
 };

--- a/services/community/report.community.service.js
+++ b/services/community/report.community.service.js
@@ -7,99 +7,95 @@ import {
 import models from "../../models/index.js";
 import logger from "../../utils/logger/logger.js";
 
-// 게시글 신고
-export const reportArticle = async ({
+/**
+ * 게시글이 존재하는지 확인합니다.
+ */
+const checkTargetExists = async (
+  targetType,
+  targetId,
   communityId,
-  articleId,
-  reportedUserId,
-  reason,
-}) => {
-  // 게시글 조회
-  const article = await models.Articles.findOne({
-    where: { communityId, articleId },
-  });
-
-  // 게시글이 존재하지 않는 경우: 404
-  if (!article) {
-    throw new NotExistsError("존재하지 않는 게시글입니다.");
+  articleId
+) => {
+  let target;
+  if (targetType === "article") {
+    target = await models.Articles.findOne({
+      where: { communityId, articleId: targetId }, // 게시글은 communityId와 articleId로 조회
+    });
+  } else if (targetType === "comment") {
+    target = await models.ArticleComments.findOne({
+      where: { articleId, commentId: targetId }, // 댓글은 articleId와 commentId로 조회
+    });
   }
 
-  // 신고자와 게시글 작성자가 같은 경우: 403
-  if (article.authorId === reportedUserId) {
-    throw new NotAllowedError("자신이 작성한 게시글은 신고할 수 없습니다.");
+  if (!target) {
+    throw new NotExistsError(`존재하지 않는 ${targetType}입니다.`);
   }
-
-  // 신고 내역 조회
-  const isReported = await models.Reports.findOne({
-    where: { targetId: articleId, reportedUserId, type: "article" },
-  });
-
-  // 이미 신고한 경우: 409
-  // 기존 방식 if (isReported)는 조건에서 targetId에 대한 검증이 없어서 테스트 코드 적용이 어려웠음
-  if (isReported.targetId === articleId) {
-    throw new AlreadyExistsError("이미 신고한 게시글입니다.");
-  }
-
-  // 신고 작성
-  const newReport = await models.Reports.create({
-    targetId: articleId,
-    reportedUserId,
-    reason,
-    type: "article",
-  });
-
-  return { newReport };
+  return target;
 };
 
-// 댓글 신고
-export const reportComment = async ({
+/**
+ * 이미 신고한 게시글인지 확인합니다.
+ */
+const checkIfAlreadyReported = async (targetId, reportedUserId, type) => {
+  const isReported = await models.Reports.findOne({
+    where: { targetId, reportedUserId, type },
+  });
+
+  if (isReported) {
+    throw new AlreadyExistsError(
+      `이미 신고한 ${type === "article" ? "게시글" : "댓글"}입니다.`
+    );
+  }
+};
+
+/**
+ * 게시글을 신고합니다.
+ */
+const createReport = async ({ targetId, reportedUserId, reason, type }) => {
+  return await models.Reports.create({
+    targetId,
+    reportedUserId,
+    reason,
+    type,
+  });
+};
+
+/**
+ * 게시글 및 댓글을 신고합니다.
+ */
+export const reportTarget = async ({
+  targetType,
   communityId,
   articleId,
-  commentId,
+  commentId = null,
   reportedUserId,
   reason,
 }) => {
-  // 댓글 조회
-  const comment = await models.ArticleComments.findOne({
-    where: { articleId, commentId },
-  });
+  const targetId = targetType === "article" ? articleId : commentId;
 
-  // 댓글이 존재하지 않는 경우: 404
-  if (!comment) {
-    logger.error(
-      `[reportComment] 댓글이 존재하지 않음 - articleId: ${articleId}, commentId: ${commentId}`
-    );
-    throw new NotExistsError("해당 댓글을 찾을 수 없습니다.");
+  await checkTargetExists(targetType, targetId, communityId, articleId);
+
+  if (targetType === "article") {
+    const article = await models.Articles.findOne({ where: { articleId } });
+    if (article.authorId === reportedUserId) {
+      throw new NotAllowedError("자신이 작성한 게시글은 신고할 수 없습니다.");
+    }
+  } else if (targetType === "comment") {
+    const comment = await models.ArticleComments.findOne({
+      where: { commentId },
+    });
+    if (comment.authorId === reportedUserId) {
+      throw new NotAllowedError("자신이 작성한 댓글은 신고할 수 없습니다.");
+    }
   }
 
-  // 신고자와 댓글 작성자가 같은 경우: 403
-  if (comment.authorId === reportedUserId) {
-    logger.error(
-      `[reportComment] 자신이 작성한 댓글은 신고할 수 없습니다 - articleId: ${articleId}, commentId: ${commentId}`
-    );
-    throw new NotAllowedError("자신이 작성한 댓글은 신고할 수 없습니다.");
-  }
+  await checkIfAlreadyReported(targetId, reportedUserId, targetType);
 
-  // 신고 내역 조회
-  const isReported = await models.Reports.findOne({
-    where: { targetId: commentId, reportedUserId, type: "comment" },
-  });
-
-  // 이미 신고한 경우: 409
-  // 기존 방식 if (isReported)는 조건에서 targetId에 대한 검증이 없어서 테스트 코드 적용이 어려웠음
-  if (isReported.targetId === commentId) {
-    logger.error(
-      `[reportComment] 이미 신고한 댓글입니다 - articleId: ${articleId}, commentId: ${commentId}`
-    );
-    throw new AlreadyExistsError("이미 신고한 댓글입니다.");
-  }
-
-  // 신고 작성
-  const newReport = await models.Reports.create({
-    targetId: commentId,
+  const newReport = await createReport({
+    targetId,
     reportedUserId,
     reason,
-    type: "comment",
+    type: targetType,
   });
 
   return { newReport };


### PR DESCRIPTION
### 진행한 작업

**ID로 게시글 조회**
- `getArticleById()` RORO 방식으로 변경 및 변수명 좀 더 직관적으로 수정

**게시글 좋아요/취소**
- `likeArticle()`과 `unlikeArticle()`에서 중복된 게시글 존재 확인 로직을 `checkArticleExists()` 유틸리티 함수로 통합
- 이를 통해 `unlikeArticle()`에서 불필요한 include를 제거하고, 별도 쿼리로 ArticleLikes 존재 여부를 확인하도록 리팩토링

**게시글 목록 조회**
- `getArticles()` 및 `getLikedArticles()` 함수 내부에서 반복되던 구문 제거
- `getThumbnail()`에서 썸네일 URL 생성
- `getAuthorInfo()`에서 작성자 정보 생성 후 불필요한 필드 삭제 처리

**댓글 좋아요/취소**
- `likeComment()`와 `unlikeComment()`에서 중복된 댓글 존재 확인 로직을 `checkCommentExists()` 유틸리티 함수로 통합
- 이를 통해 `unlikeComment()`에서 불필요한 include를 제거하고, 별도 쿼리로 ArticleCommentLikes 존재 여부를 확인하도록 리팩토링

**게시글/댓글 신고**
- 게시글 및 댓글 존재 여부 확인하는 `checkTargetExists()`, 이미 신고한 게시글 혹은 댓글인지 확인하는 `checkIfAlreadyReported()`, 신고를 작성하는 `createReport()`가 공통으로 존재하는 로직이라 분리하였습니다.
- controller에서 불필요하게 반환하던 report에 대한 내용은 제거하고 성공 메시지만 반환하도록 하였습니다.