### PR TITLE
익명 댓글 번호 할당

### DIFF
--- a/models/database/ArticleComments.js
+++ b/models/database/ArticleComments.js
@@ -43,7 +43,7 @@ export default class ArticleComments extends Model {
       field: 'author_id'
     },
     isAnonymous: {
-      type: DataTypes.BOOLEAN,
+      type: DataTypes.BIGINT.UNSIGNED,
       allowNull: false,
       field: 'is_anonymous'
     },

--- a/services/community/article.crud.community.service.js
+++ b/services/community/article.crud.community.service.js
@@ -119,8 +119,14 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
 
   // 댓글 정보에 좋아요 여부, 좋아요 개수 및 작성자 정보 추가
   const transformedComments = data.articleComments.map((comment) => {
-    const { author, articleCommentLikes, status, content, ...commentData } =
-      comment.dataValues;
+    const {
+      author,
+      articleCommentLikes,
+      status,
+      content,
+      isAnonymous,
+      ...commentData
+    } = comment.dataValues;
 
     const isCommentLikedByUser = userId
       ? articleCommentLikes.some(
@@ -132,12 +138,22 @@ export const getArticleById = async ({ communityId, articleId, userId }) => {
     // status가 'deleted'인 경우 content를 빈 문자열로 설정
     const processedContent = status === "deleted" ? "" : content;
 
+    // 익명 처리 로직: isAnonymous 값에 따라 익명 닉네임 설정
+    let transformedAuthorInfo = author;
+    // isAnonymous가 0이 아닌 양의 정수일 경우 익명이 됨
+    if (isAnonymous !== 0) {
+      transformedAuthorInfo = {
+        nickname: `익명${isAnonymous}`, // isAnonymous 값을 그대로 사용하여 익명 번호 지정
+        profileImage: null,
+        authorId: null,
+      };
+    }
     return {
-      // 댓글에 대한 정보
-      authorInfo: status === "deleted" ? null : author,
+      authorInfo: status === "deleted" ? null : transformedAuthorInfo,
       isLikedByUser: isCommentLikedByUser,
       commentLikesCount: status === "deleted" ? 0 : commentLikesCount,
       content: processedContent,
+      isAnonymous,
       status, // 상태 정보도 포함해 응답
       ...commentData,
     };


### PR DESCRIPTION
### 설명
- 게시글 단위로, 동일 사용자(authorId)에 대해 하나의 익명 번호만 할당되도록 구현
- 기존 익명 댓글이 있으면 해당 익명 번호를 바로 가져오고, 없으면 게시글 내 가장 큰 익명 번호의 다음 번호를 할당
#### 예시
- 사용자 1이 해당 게시글에 익명 댓글을 처음 단 경우 → 익명1
- 사용자 1이 동일 게시글에 추가로 익명 댓글을 작성하면 이전에 부여된 익명 번호 익명1 재사용
- 사용자 2가 익명 댓글을 작성하면 → 기존 익명 번호들 중 최댓값 + 1 → 익명2
---
### 진행한 작업
- [x] 설명한 로직에 따라 `createComment()` 수정
- [x] 변경한 로직에 따라 `getArticleById()`와 `getComments()`에서 isAnonymous 값을 사용하여 댓글 사용자명 익명{isAnonymous}로 처리하도록 수정
- [x] DB에서 isAnonymous unsigned bigint로 변경
- [x] 노션 수정